### PR TITLE
Fixed edge case in determining correct wrapper name/version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+## [2.0.1] - 2022-04-27
+
+### Fixed
+
+- Fixed edge case in determining correct wrapper name/version.
+
 ## [2.0.0] - 2022-04-26
 
 ### Changed
@@ -45,7 +51,8 @@ This project adheres to [Semantic Versioning].
 
 Initial public release.
 
-[Unreleased]:   https://github.com/waldoapp/waldo-go-cli/compare/2.0.0...HEAD
+[Unreleased]:   https://github.com/waldoapp/waldo-go-cli/compare/2.0.1...HEAD
+[2.0.1]:        https://github.com/waldoapp/waldo-go-cli/compare/2.0.0...2.0.1
 [2.0.0]:        https://github.com/waldoapp/waldo-go-cli/compare/1.1.3...2.0.0
 [1.1.3]:        https://github.com/waldoapp/waldo-go-cli/compare/1.1.2...1.1.3
 [1.1.3]:        https://github.com/waldoapp/waldo-go-cli/compare/1.1.2...1.1.3

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	cliName    = "Waldo CLI"
-	cliVersion = "2.0.0"
+	cliVersion = "2.0.1"
 
 	cliAssetBaseURL = "https://github.com/waldoapp/waldo-go-agent/releases"
 )
@@ -177,8 +177,17 @@ func dumpResponse(resp *http.Response, body bool) {
 func enrichEnvironment() []string {
 	env := os.Environ()
 
-	setEnvironVar(&env, "WALDO_WRAPPER_NAME_OVERRIDE", cliName)
-	setEnvironVar(&env, "WALDO_WRAPPER_VERSION_OVERRIDE", cliVersion)
+	//
+	// If _both_ wrapper overrides are already set, do _not_ replace them with
+	// the CLI name/version:
+	//
+	wrapperName := os.Getenv("WALDO_WRAPPER_NAME_OVERRIDE")
+	wrapperVersion := os.Getenv("WALDO_WRAPPER_VERSION_OVERRIDE")
+
+	if len(wrapperName) == 0 || len(wrapperVersion) == 0 {
+		setEnvironVar(&env, "WALDO_WRAPPER_NAME_OVERRIDE", cliName)
+		setEnvironVar(&env, "WALDO_WRAPPER_VERSION_OVERRIDE", cliVersion)
+	}
 
 	return env
 }


### PR DESCRIPTION
This was causing the custom Waldo GitHub action to report the incorrect wrapper name/version.