### PR TITLE
Added: Advanced Variables

### DIFF
--- a/sim_appcenter_build_and_upload.sh
+++ b/sim_appcenter_build_and_upload.sh
@@ -44,8 +44,9 @@ function create_sim_build() {
 
 function upload_sim_build() {
     local _build_path="$SIM_XCODE_DATA_PATH"/Build/Products/"$SIM_XCODE_CONFIGURATION"-iphonesimulator/"$SIM_XCODE_APP_NAME"
+    local _advanced_variables=${SIM_APPCENTER_ADVANCED_VARIABLES:-}
 
-    ${WALDO_CLI_BIN}/waldo upload "$_build_path"
+    ${WALDO_CLI_BIN}/waldo upload "$_build_path" $_advanced_variables
 }
 
 create_sim_build || exit

--- a/sim_appcenter_build_and_upload.sh
+++ b/sim_appcenter_build_and_upload.sh
@@ -44,9 +44,9 @@ function create_sim_build() {
 
 function upload_sim_build() {
     local _build_path="$SIM_XCODE_DATA_PATH"/Build/Products/"$SIM_XCODE_CONFIGURATION"-iphonesimulator/"$SIM_XCODE_APP_NAME"
-    local _advanced_variables=${SIM_APPCENTER_ADVANCED_VARIABLES:-}
+    local _upload_options=${SIM_WALDO_UPLOAD_OPTIONS:-}
 
-    ${WALDO_CLI_BIN}/waldo upload "$_build_path" $_advanced_variables
+    ${WALDO_CLI_BIN}/waldo upload "$_build_path" $_upload_options
 }
 
 create_sim_build || exit


### PR DESCRIPTION
The sim_appcenter_build_and_upload.sh script does not currently support the use of the advanced flags for the Waldo CLI. Adding this SIM_APPCENTER_ADVANCED_VARIABLES allows users to choose to set a variables with the flags they wish to use. 