### PR TITLE
Update sim_appcenter_build_and_upload.sh

### DIFF
--- a/sim_appcenter_build_and_upload.sh
+++ b/sim_appcenter_build_and_upload.sh
@@ -26,14 +26,14 @@ function create_sim_build() {
     local _xcode_project_suffix=${SIM_XCODE_PROJECT##*.}
 
     if [[ $_xcode_project_suffix == "xcworkspace" ]]; then
-        xcodebuild -workspace "$SIM_XCODE_PROJECT"                  \
+        xcodebuild $SIM_XCODE_OPTIONS -workspace "$SIM_XCODE_PROJECT"                  \
                    -scheme "$SIM_XCODE_SCHEME"                      \
                    -configuration "$SIM_XCODE_CONFIGURATION"        \
                    -destination 'generic/platform=iOS Simulator'    \
                    -derivedDataPath "$SIM_XCODE_DATA_PATH"          \
                    clean build
     else
-        xcodebuild -project "$SIM_XCODE_PROJECT"                    \
+        xcodebuild $SIM_XCODE_OPTIONS -project "$SIM_XCODE_PROJECT"                    \
                    -scheme "$SIM_XCODE_SCHEME"                      \
                    -configuration "$SIM_XCODE_CONFIGURATION"        \
                    -destination 'generic/platform=iOS Simulator'    \


### PR DESCRIPTION
The addition of this variable allows us to set options for how xcode is building the app. This became necessary when we upgraded to React Native 0.68.2 and found we had to specify `ARCHS=x86_64 ONLY_ACTIVE_ARCH=NO` as build options to properly build a simulator build for Waldo

we are using this in our `appcenter-pre-build.sh` script as `export SIM_XCODE_OPTIONS=ARCHS=x86_64 ONLY_ACTIVE_ARCH=NO`