### PR TITLE
Updated docs for new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+## [3.2.0] - 2023-07-26
+
+### Added
+
+- Added support for React Native (non-Expo) recipes.
+
 ## [3.1.0] - 2023-06-14
 
 ### Added
@@ -116,7 +122,8 @@ Initial public release of enhanced functionality.
 
 Initial public release.
 
-[Unreleased]:   https://github.com/waldoapp/waldo-go-cli/compare/3.1.0...HEAD
+[Unreleased]:   https://github.com/waldoapp/waldo-go-cli/compare/3.2.0...HEAD
+[3.2.0]:		https://github.com/waldoapp/waldo-go-cli/compare/3.1.0...3.2.0
 [3.1.0]:		https://github.com/waldoapp/waldo-go-cli/compare/3.0.0...3.1.0
 [3.0.0]:		https://github.com/waldoapp/waldo-go-cli/compare/2.0.5...3.0.0
 [2.0.5]:        https://github.com/waldoapp/waldo-go-cli/compare/2.0.4...2.0.5

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   - Xcode (see [here](https://docs.waldo.com/docs/exporting-your-build-for-waldo) for details)
   - Gradle
   - Flutter
+  - React Native (non-Expo)
   - _…and more to come!_
 - Upload an iOS or Android build to Waldo for processing. See [here](https://docs.waldo.com/docs/ios-uploading-your-simulator-build-to-waldo) and [here](https://docs.waldo.com/docs/android-uploading-your-emulator-build-to-waldo) for more details.
 - Trigger a run of of one or more test flows for your app. See [here](https://docs.waldo.com/docs/ci-run) for more details.

--- a/waldo/data/global.go
+++ b/waldo/data/global.go
@@ -3,5 +3,5 @@ package data
 const (
 	CLIName    = "Waldo CLI"
 	CLIPrefix  = "waldo"
-	CLIVersion = "3.1.0"
+	CLIVersion = "3.2.0"
 )


### PR DESCRIPTION
Going to push out the React Native (non-Expo) support by itself now, rather than wait to include Expo support.
