### PR TITLE
Make installer scripts more lenient

### DIFF
--- a/install-waldo.sh
+++ b/install-waldo.sh
@@ -21,7 +21,13 @@ function detect_ci_mode() {
     local _ci_mode=${CI:-}
 
     if [[ $_ci_mode != true && $_ci_mode != 1 ]]; then
-        fail "No CI environment detected -- please use ‘install.sh’ instead"
+        echo ""
+        echo "    +-----------------------------------------------+"
+        echo "    |          No CI environment detected:          |"
+        echo "    | If you intend to use Waldo CLI interactively, |"
+        echo "    |        please use ‘install.sh’ instead        |"
+        echo "    +-----------------------------------------------+"
+        echo ""
     fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -112,7 +112,13 @@ function detect_ci_mode() {
     local _ci_mode=${CI:-}
 
     if [[ $_ci_mode == true || $_ci_mode == 1 ]]; then
-        fail "CI environment detected -- please use ‘install-waldo.sh’ instead"
+        echo ""
+        echo "    +--------------------------------------------------+"
+        echo "    |            CI environment detected:              |"
+        echo "    | If you intend to use Waldo CLI from a CI script, |"
+        echo "    |      please use ‘install-waldo.sh’ instead       |"
+        echo "    +--------------------------------------------------+"
+        echo ""
     fi
 }
 


### PR DESCRIPTION
- If invoked in the “wrong” CI environment, both `install-waldo.sh` and `install.sh` now print a big warning message to stdout instead of failing.